### PR TITLE
Bump symfony version and remove deprecated call

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "friends-of-behat/symfony-extension": "^2.0",
         "friends-of-behat/variadic-extension": "^1.1",
         "lakion/mink-debug-extension": "^1.2.3",
-        "phpspec/phpspec": "^5.0",
+        "phpspec/phpspec": "^6.0",
         "phpstan/phpstan-doctrine": "^0.10",
         "phpstan/phpstan-shim": "^0.10",
         "phpstan/phpstan-symfony": "^0.10",
@@ -27,19 +27,12 @@
         "roave/security-advisories": "dev-master",
         "sensiolabs/security-checker": "^5.0",
         "sylius-labs/coding-standard": "^2.0",
-        "symfony/browser-kit": "^3.4|^4.1",
-        "symfony/debug-bundle": "^3.4|^4.1",
-        "symfony/dotenv": "^4.2",
-        "symfony/intl": "^3.4|^4.1",
-        "symfony/web-profiler-bundle": "^3.4|^4.1",
-        "symfony/web-server-bundle": "^3.4|^4.1"
-    },
-    "conflict": {
-        "symfony/symfony": "4.1.8",
-        "symfony/browser-kit": "4.1.8",
-        "symfony/dependency-injection": "4.1.8",
-        "symfony/dom-crawler": "4.1.8",
-        "symfony/routing": "4.1.8"
+        "symfony/browser-kit": "^4.3|^5.0",
+        "symfony/debug-bundle": "^4.3|^5.0",
+        "symfony/dotenv": "^4.3|^5.0",
+        "symfony/intl": "^4.3|^5.0",
+        "symfony/web-profiler-bundle": "^4.3|^5.0",
+        "symfony/web-server-bundle": "^4.3|^5.0"
     },
     "prefer-stable": true,
     "autoload": {
@@ -57,7 +50,11 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "symfony/thanks": true
+        }
     },
     "scripts": {
         "check-style": "./vendor/bin/ecs check src",

--- a/src/Form/Extension/ProductVariantTypeExtension.php
+++ b/src/Form/Extension/ProductVariantTypeExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\Currencies;
 
 class ProductVariantTypeExtension extends AbstractTypeExtension
 {
@@ -29,7 +29,7 @@ class ProductVariantTypeExtension extends AbstractTypeExtension
     public function __construct(LocaleContextInterface $locale, CurrencyContextInterface $currencyContext)
     {
         $this->preferredCurrency = $currencyContext->getCurrencyCode();
-        $this->preferredCurrencyName = Intl::getCurrencyBundle()->getCurrencyNames($locale->getLocaleCode())[$this->preferredCurrency];
+        $this->preferredCurrencyName = Currencies::getName($this->preferredCurrency, $locale->getLocaleCode());
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void


### PR DESCRIPTION
In Symfony Intl 4.3: 

4.3.0
-----

 * added `Currencies` in favor of `Intl::getCurrencyBundle()`

And it was removed in 5.0